### PR TITLE
improvement: support openssl 3; deprecate PKey::*#set_*

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,11 @@ jobs:
           gem install bundler
           bundle --version
           bundle install
-      - name: Run test
-        run: |
-          bundle exec rake
-          bundle exec rake interop:client
-          bundle exec rake interop:server
+      - name: Run rubocop
+        run: bundle exec rake rubocop
+      - name: Run rspec
+        run: bundle exec rake spec
+      - name: Run interop client
+        run: bundle exec rake interop:client
+      - name: Run interop server
+        run: bundle exec rake interop:server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         ruby-version: ['2.7.x', '3.0.x', '3.1.x']
     steps:
       - uses: actions/checkout@v3
-      - uses: docker://thekuwayama/openssl:latest
+      - uses: docker://thekuwayama/openssl:3.0.7-x86_64
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/lib/tttls1.3/connection.rb
+++ b/lib/tttls1.3/connection.rb
@@ -517,10 +517,8 @@ module TTTLS13
     #
     # @return [Array of TTTLS13::Message::Extension::SignatureAlgorithms]
     def do_select_signature_algorithms(signature_algorithms, crt)
-      spki = OpenSSL::Netscape::SPKI.new
-      spki.public_key = crt.public_key
-      pka = OpenSSL::ASN1.decode(spki.to_der)
-                         .value.first.value.first.value.first.value.first.value
+      pka = OpenSSL::ASN1.decode(crt.public_key.to_der)
+                         .value.first.value.first.value
       signature_algorithms.select do |sa|
         case sa
         when SignatureScheme::ECDSA_SECP256R1_SHA256,

--- a/lib/tttls1.3/message/extension/key_share.rb
+++ b/lib/tttls1.3/message/extension/key_share.rb
@@ -114,8 +114,7 @@ module TTTLS13
         # @return [OpenSSL::PKey::EC.$Object]
         def self.gen_sh_key_share(group)
           curve = NamedGroup.curve_name(group)
-          ec = OpenSSL::PKey::EC.new(curve)
-          ec.generate_key!
+          ec = OpenSSL::PKey::EC.generate(curve)
 
           key_share = KeyShare.new(
             msg_type: HandshakeType::SERVER_HELLO,

--- a/lib/tttls1.3/message/extension/key_share.rb
+++ b/lib/tttls1.3/message/extension/key_share.rb
@@ -91,8 +91,7 @@ module TTTLS13
           priv_keys = {}
           kse = groups.map do |group|
             curve = NamedGroup.curve_name(group)
-            ec = OpenSSL::PKey::EC.new(curve)
-            ec.generate_key!
+            ec = OpenSSL::PKey::EC.generate(curve)
             # store private key to do the key-exchange
             priv_keys.store(group, ec)
             KeyShareEntry.new(

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -6,13 +6,28 @@ require_relative 'spec_helper'
 RSpec.describe Connection do
   context 'connection, Simple 1-RTT Handshake,' do
     let(:key) do
-      rsa = OpenSSL::PKey::RSA.new
-      rsa.set_key(OpenSSL::BN.new(TESTBINARY_PKEY_MODULUS, 2),
-                  OpenSSL::BN.new(TESTBINARY_PKEY_PUBLIC_EXPONENT, 2),
-                  OpenSSL::BN.new(TESTBINARY_PKEY_PRIVATE_EXPONENT, 2))
-      rsa.set_factors(OpenSSL::BN.new(TESTBINARY_PKEY_PRIME1, 2),
-                      OpenSSL::BN.new(TESTBINARY_PKEY_PRIME2, 2))
-      rsa
+      n = OpenSSL::BN.new(TESTBINARY_PKEY_MODULUS, 2)
+      e = OpenSSL::BN.new(TESTBINARY_PKEY_PUBLIC_EXPONENT, 2)
+      d = OpenSSL::BN.new(TESTBINARY_PKEY_PRIVATE_EXPONENT, 2)
+      p = OpenSSL::BN.new(TESTBINARY_PKEY_PRIME1, 2)
+      q = OpenSSL::BN.new(TESTBINARY_PKEY_PRIME2, 2)
+      dmp1 = d % (p - 1.to_bn)
+      dmq1 = d % (q - 1.to_bn)
+      iqmp = q**-1.to_bn % p
+      asn1 = OpenSSL::ASN1::Sequence(
+        [
+          OpenSSL::ASN1::Integer(0),
+          OpenSSL::ASN1::Integer(n),
+          OpenSSL::ASN1::Integer(e),
+          OpenSSL::ASN1::Integer(d),
+          OpenSSL::ASN1::Integer(p),
+          OpenSSL::ASN1::Integer(q),
+          OpenSSL::ASN1::Integer(dmp1),
+          OpenSSL::ASN1::Integer(dmq1),
+          OpenSSL::ASN1::Integer(iqmp)
+        ]
+      )
+      OpenSSL::PKey::RSA.new(asn1)
     end
 
     let(:ct) do

--- a/spec/extensions_spec.rb
+++ b/spec/extensions_spec.rb
@@ -35,8 +35,7 @@ RSpec.describe Extensions do
   end
 
   let(:key_share) do
-    ec = OpenSSL::PKey::EC.new('prime256v1')
-    ec.generate_key!
+    ec = OpenSSL::PKey::EC.generate('prime256v1')
     KeyShare.new(
       msg_type: HandshakeType::CLIENT_HELLO,
       key_share_entry: [

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -109,13 +109,28 @@ RSpec.describe Server do
 
   context 'server' do
     let(:key) do
-      rsa = OpenSSL::PKey::RSA.new
-      rsa.set_key(OpenSSL::BN.new(TESTBINARY_PKEY_MODULUS, 2),
-                  OpenSSL::BN.new(TESTBINARY_PKEY_PUBLIC_EXPONENT, 2),
-                  OpenSSL::BN.new(TESTBINARY_PKEY_PRIVATE_EXPONENT, 2))
-      rsa.set_factors(OpenSSL::BN.new(TESTBINARY_PKEY_PRIME1, 2),
-                      OpenSSL::BN.new(TESTBINARY_PKEY_PRIME2, 2))
-      rsa
+      n = OpenSSL::BN.new(TESTBINARY_PKEY_MODULUS, 2)
+      e = OpenSSL::BN.new(TESTBINARY_PKEY_PUBLIC_EXPONENT, 2)
+      d = OpenSSL::BN.new(TESTBINARY_PKEY_PRIVATE_EXPONENT, 2)
+      p = OpenSSL::BN.new(TESTBINARY_PKEY_PRIME1, 2)
+      q = OpenSSL::BN.new(TESTBINARY_PKEY_PRIME2, 2)
+      dmp1 = d % (p - 1.to_bn)
+      dmq1 = d % (q - 1.to_bn)
+      iqmp = q**-1.to_bn % p
+      asn1 = OpenSSL::ASN1::Sequence(
+        [
+          OpenSSL::ASN1::Integer(0),
+          OpenSSL::ASN1::Integer(n),
+          OpenSSL::ASN1::Integer(e),
+          OpenSSL::ASN1::Integer(d),
+          OpenSSL::ASN1::Integer(p),
+          OpenSSL::ASN1::Integer(q),
+          OpenSSL::ASN1::Integer(dmp1),
+          OpenSSL::ASN1::Integer(dmq1),
+          OpenSSL::ASN1::Integer(iqmp)
+        ]
+      )
+      OpenSSL::PKey::RSA.new(asn1)
     end
 
     let(:ct) do


### PR DESCRIPTION
`OpenSSL::PKey::EC#generate_key!`, `OpenSSL::PKey::RSA#set_key`, `OpenSSL::PKey::RSA#set_factors` is deprecated.