### PR TITLE
fix: spec.required_ruby_version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 AllCops:
   TargetRubyVersion: 2.7
 
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
 Style/ConditionalAssignment:
   Enabled: false
 

--- a/tttls1.3.gemspec
+++ b/tttls1.3.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description   = spec.summary
   spec.homepage      = 'https://github.com/thekuwayama/tttls1.3'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>=2.7'
+  spec.required_ruby_version = '>=3.1'
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
> hpke-0.1.0 requires ruby version >= 3.1.0