### PR TITLE
clean: OpenSSL::X509::Certificate ocsp_uris define_method を削除

### DIFF
--- a/lib/tttls1.3/utils.rb
+++ b/lib/tttls1.3/utils.rb
@@ -69,21 +69,6 @@ module TTTLS13
         length.to_uint64 + self
       end
     end
-
-    refine OpenSSL::X509::Certificate do
-      unless method_defined?(:ocsp_uris)
-        define_method(:ocsp_uris) do
-          aia = extensions.find { |ex| ex.oid == 'authorityInfoAccess' }
-          return nil if aia.nil?
-
-          ostr = OpenSSL::ASN1.decode(aia.to_der).value.last
-          ocsp = OpenSSL::ASN1.decode(ostr.value)
-                              .map(&:value)
-                              .select { |des| des.first.value == 'OCSP' }
-          ocsp&.map { |o| o[1].value }
-        end
-      end
-    end
   end
 
   module Convert


### PR DESCRIPTION
https://github.com/thekuwayama/tttls1.3/blob/0b7a53051caf96ea06fab4ddcd56ab4461695be7/tttls1.3.gemspec#L26

によって、ocsp_uris メソッドを生やさなくて良くなりました。削除します。